### PR TITLE
Fix compiler errors and warnings on FreeBSD:

### DIFF
--- a/frontend/CMakeLists.txt
+++ b/frontend/CMakeLists.txt
@@ -104,8 +104,10 @@ target_compile_features(clownmdemufrontend PRIVATE cxx_long_long_type cxx_static
 # Disable some deprecated junk in Dear ImGui
 target_compile_definitions(clownmdemufrontend PRIVATE IMGUI_DISABLE_OBSOLETE_FUNCTIONS IMGUI_DISABLE_OBSOLETE_KEYIO)
 
-# Dear ImGui needs these directories in the include path
-target_include_directories(clownmdemufrontend PRIVATE "libraries/imgui" "libraries/imgui/backends")
+# Pick up imgui headers from the submodule directory, and add /usr/local/include
+# for OSes where libx11 is not installed out of the box. Note that CMake does not
+# treat /usr/local/include as a system directory.
+target_include_directories(clownmdemufrontend PRIVATE "/usr/local/include" "libraries/imgui" "libraries/imgui/backends")
 
 
 #

--- a/frontend/main.cpp
+++ b/frontend/main.cpp
@@ -1557,7 +1557,7 @@ int main(int argc, char **argv)
 
 								ImGui::MenuItem("Tall Double Resolution Mode", NULL, &tall_double_resolution_mode);
 
-								if (ImGui::MenuItem("Low-Pass Filter", NULL, &low_pass_filter))
+								if (ImGui::MenuItem("Low-Pass Filter", NULL, low_pass_filter))
 									Mixer_State_Initialise(&mixer_state, audio_device_sample_rate, pal_mode, low_pass_filter);
 
 								ImGui::MenuItem("Pop-Out Display Window", NULL, &pop_out);


### PR DESCRIPTION
1. Put /usr/local/include in the include path so X11 headers get picked up on the BSDs.
2. Fixed a Clang compiler warning in main.cpp which amounted to passing a pointer as a bool value.