### PR TITLE
Fix broken KDebug logging and buffer overflow

### DIFF
--- a/vdp.c
+++ b/vdp.c
@@ -1039,7 +1039,10 @@ void VDP_WriteControl(const VDP* const vdp, const cc_u16f value, const VDP_Colou
 
 				/* The last byte of the buffer is always set to 0, so we don't need to do it here. */
 				if (character == '\0' || vdp->state->kdebug_buffer_index == CC_COUNT_OF(vdp->state->kdebug_buffer) - 1)
-						kdebug_callback((void*)kdebug_callback_user_data, vdp->state->kdebug_buffer);
+				{
+					vdp->state->kdebug_buffer_index = 0;
+					kdebug_callback((void*)kdebug_callback_user_data, vdp->state->kdebug_buffer);
+				}
 
 				break;
 			}


### PR DESCRIPTION
KDebug integration is broken in v.0.8 due to an unfortunate bug.

![image](https://github.com/user-attachments/assets/befa06ed-2187-40f4-a56a-66fb424fe8f4)

Once the first KDebug message is flushed, buffer position is never reset so further messages are appended to the end of it and buffer eventually overflows, overwriting other memory structures and causing random bugs or SEGFAULTs.